### PR TITLE
Removed isLinux condition in flake.nix for cocotb package for macOS compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,10 @@
           surfer
         ];
         
-        extra-python-packages = with pkgs.python3.pkgs; (pkgs.lib.optionals pkgs.stdenv.isLinux [
+        extra-python-packages = with pkgs.python3.pkgs; [
           # Verification
           cocotb
-        ]);
+        ];
       }) {};
     });
   };


### PR DESCRIPTION
Fixes #7 