### PR TITLE
Add support for different slot sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || !(startsWith(github.ref_name, 'version-') || github.ref_name == 'main' || github.ref_name == 'dev') }}
 
 jobs:
+  pre:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Define the Matrix
+        id: export-slots
+        if: 
+        run: |
+          if ${{ github.repository == 'wafer-space/gf180mcu-project-template' }}; then
+            echo "slots=['1x1', '0p5x1', '1x0p5', '0p5x0p5']" >> $GITHUB_OUTPUT
+          else
+            echo "slots=['default']" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      matrix: ${{ steps.export-slots.outputs.slots }}
   chip:
     runs-on: ubuntu-24.04
     name: Build the Chip
+    needs:
+      - pre
+    strategy:
+      matrix:
+        slot: ${{fromJSON(needs.pre.outputs.matrix)}}
     steps:
+      - name: Set slot
+        run: echo "SLOT=${{ matrix.slot }}" >> $GITHUB_ENV
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v5
         with:
@@ -73,12 +94,12 @@ jobs:
       - name: Upload GDS
         uses: actions/upload-artifact@v4
         with:
-          name: gds
+          name: ${{ matrix.slot }}_gds
           path: final/gds/*
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:
-          name: image
+          name: ${{ matrix.slot }}_image
           path: img/*.png
       - name: Run GL simulation
         run: |

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,20 @@ PDK_ROOT ?= $(MAKEFILE_DIR)/gf180mcu
 PDK ?= gf180mcuD
 PDK_TAG ?= 1.1.0
 
+AVAILABLE_SLOTS = 1x1 0p5x1 1x0p5 0p5x0p5
+DEFAULT_SLOT = 1x1
+
+# Slot can be any of AVAILABLE_SLOTS
+SLOT ?= $(DEFAULT_SLOT)
+
+ifeq ($(SLOT),default)        
+    SLOT = $(DEFAULT_SLOT)
+endif
+
+ifeq ($(filter $(SLOT),$(AVAILABLE_SLOTS)),)
+    $(error $(SLOT) does not exist in AVAILABLE_SLOTS: $(AVAILABLE_SLOTS))
+endif
+
 .DEFAULT_GOAL := help
 
 help: ## Show this help message
@@ -25,35 +39,35 @@ clone-pdk: ## Clone the GF180MCU PDK repository
 .PHONY: clone-pdk
 
 librelane: ## Run LibreLane flow (synthesis, PnR, verification)
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk
 .PHONY: librelane
 
 librelane-nodrc: ## Run LibreLane flow without DRC checks
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip KLayout.DRC --skip Magic.DRC
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip KLayout.DRC --skip Magic.DRC
 .PHONY: librelane-nodrc
 
 librelane-klayoutdrc: ## Run LibreLane flow without magic DRC checks
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip Magic.DRC
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip Magic.DRC
 .PHONY: librelane-klayoutdrc
 
 librelane-magicdrc: ## Run LibreLane flow without KLayout DRC checks
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip KLayout.DRC
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --skip KLayout.DRC
 .PHONY: librelane-magicdrc
 
 librelane-openroad: ## Open the last run in OpenROAD
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --last-run --flow OpenInOpenROAD
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --last-run --flow OpenInOpenROAD
 .PHONY: librelane-openroad
 
 librelane-klayout: ## Open the last run in KLayout
-	librelane librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --last-run --flow OpenInKLayout
+	librelane librelane/slots/slot_${SLOT}.yaml librelane/config.yaml --pdk ${PDK} --pdk-root ${PDK_ROOT} --manual-pdk --last-run --flow OpenInKLayout
 .PHONY: librelane-klayout
 
 sim: ## Run RTL simulation with cocotb
-	cd cocotb; PDK_ROOT=${PDK_ROOT} PDK=${PDK} python3 chip_top_tb.py
+	cd cocotb; PDK_ROOT=${PDK_ROOT} PDK=${PDK} SLOT=${SLOT} python3 chip_top_tb.py
 .PHONY: sim
 
 sim-gl: ## Run gate-level simulation with cocotb (after copy-final)
-	cd cocotb; GL=1 PDK_ROOT=${PDK_ROOT} PDK=${PDK} python3 chip_top_tb.py
+	cd cocotb; GL=1 PDK_ROOT=${PDK_ROOT} PDK=${PDK} SLOT=${SLOT} python3 chip_top_tb.py
 .PHONY: sim-gl
 
 sim-view: ## View simulation waveforms in GTKWave

--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ To implement your own design, simply edit `chip_core.sv`. The `chip_core` module
 > [!NOTE]
 > For more comprehensive SystemVerilog support, enable the `USE_SLANG` variable in the LibreLane configuration.
 
+## Choosing a Different Slot Size
+
+The template supports the following slot sizes: `1x1`, `0p5x1`, `1x0p5`, `0p5x0p5`.
+By default, the design is implemented using the `1x1` slot definition.
+
+To select a different slot size, simply set the `SLOT` environment variable.
+This can be done when invoking a make target:
+
+```
+SLOT=0p5x0p5 make librelane
+```
+
+Alternatively, you can export the slot size:
+
+```
+export SLOT=0p5x0p5
+```
+
+You can change the slot that is selected by default in the Makefile by editing the value of `DEFAULT_SLOT`.
+
 ## Precheck
 
 To check whether your design is suitable for manufacturing, run the [gf180mcu-precheck](https://github.com/wafer-space/gf180mcu-precheck) with your layout.

--- a/cocotb/chip_top_tb.py
+++ b/cocotb/chip_top_tb.py
@@ -16,6 +16,7 @@ pdk_root = os.getenv("PDK_ROOT", Path("~/.ciel").expanduser())
 pdk = os.getenv("PDK", "gf180mcuD")
 scl = os.getenv("SCL", "gf180mcu_fd_sc_mcu7t5v0")
 gl = os.getenv("GL", False)
+slot = os.getenv("SLOT", "1x1")
 
 hdl_toplevel = "chip_top"
 
@@ -86,8 +87,8 @@ def chip_top_runner():
     proj_path = Path(__file__).resolve().parent
 
     sources = []
-    defines = {}
-    includes = []
+    defines = {f"SLOT_{slot.upper()}": True}
+    includes = [proj_path / "../src/"]
 
     if gl:
         # SCL models

--- a/librelane/config.yaml
+++ b/librelane/config.yaml
@@ -35,109 +35,6 @@ VERILOG_FILES:
 # Slightly smaller file sizes
 PRIMARY_GDSII_STREAMOUT_TOOL: klayout
 
-# Specify the pad instances for the padring
-PAD_SOUTH: [
-    clk_pad,
-    rst_n_pad,
-
-    "bidir\\[0\\].pad",
-    "bidir\\[1\\].pad",
-    "bidir\\[2\\].pad",
-    "bidir\\[3\\].pad",
-    "bidir\\[4\\].pad",
-    "bidir\\[5\\].pad",
-
-    "dvss_pads\\[0\\].pad",
-
-    "bidir\\[6\\].pad",
-    "bidir\\[7\\].pad",
-    "bidir\\[8\\].pad",
-    "bidir\\[9\\].pad",
-    "bidir\\[10\\].pad",
-    "bidir\\[11\\].pad",
-    "bidir\\[12\\].pad",
-    "bidir\\[13\\].pad"
-]
-
-PAD_EAST: [
-    "dvdd_pads\\[0\\].pad",
-    "dvss_pads\\[1\\].pad",
-
-    "bidir\\[14\\].pad",
-    "bidir\\[15\\].pad",
-    "bidir\\[16\\].pad",
-    "bidir\\[17\\].pad",
-    "bidir\\[18\\].pad",
-    "bidir\\[19\\].pad",
-    
-    "dvdd_pads\\[1\\].pad",
-    "dvss_pads\\[2\\].pad",
-
-    
-    "bidir\\[20\\].pad",
-    "bidir\\[21\\].pad",
-    "bidir\\[22\\].pad",
-    "bidir\\[23\\].pad",
-    "bidir\\[24\\].pad",
-    "bidir\\[25\\].pad",
-    
-    "dvss_pads\\[3\\].pad",
-    "dvdd_pads\\[2\\].pad",
-    "dvss_pads\\[4\\].pad",
-    "dvdd_pads\\[3\\].pad",
-]
-
-PAD_NORTH: [
-    "analog\\[1\\].pad",
-    "analog\\[0\\].pad",
-    "bidir\\[39\\].pad",
-    "bidir\\[38\\].pad",
-    "bidir\\[37\\].pad",
-    "bidir\\[36\\].pad",
-    "bidir\\[35\\].pad",
-    "bidir\\[34\\].pad",
-
-    "dvss_pads\\[5\\].pad",
-
-    "bidir\\[33\\].pad",
-    "bidir\\[32\\].pad",
-    "bidir\\[31\\].pad",
-    "bidir\\[30\\].pad",
-    "bidir\\[29\\].pad",
-    "bidir\\[28\\].pad",
-    "bidir\\[27\\].pad",
-    "bidir\\[26\\].pad"
-]
-
-
-PAD_WEST: [
-    "dvdd_pads\\[7\\].pad",
-    "dvss_pads\\[9\\].pad",
-    "dvdd_pads\\[6\\].pad",
-    "dvss_pads\\[8\\].pad",
-
-    "inputs\\[11\\].pad",
-    "inputs\\[10\\].pad",
-    "inputs\\[9\\].pad",
-    "inputs\\[8\\].pad",
-    "inputs\\[7\\].pad",
-    "inputs\\[6\\].pad",
-
-    "dvdd_pads\\[5\\].pad",
-    "dvss_pads\\[7\\].pad",
-
-    "inputs\\[5\\].pad",
-    "inputs\\[4\\].pad",
-    "inputs\\[3\\].pad",
-    "inputs\\[2\\].pad",
-
-    "dvdd_pads\\[4\\].pad",
-    "dvss_pads\\[6\\].pad",
-    
-    "inputs\\[1\\].pad",
-    "inputs\\[0\\].pad"
-]
-
 # SDC files
 PNR_SDC_FILE: dir::chip_top.sdc
 SIGNOFF_SDC_FILE: dir::chip_top.sdc
@@ -164,13 +61,6 @@ CLOCK_PERIOD: 40 # 25 MHz
 # Fix hold violations
 PL_RESIZER_HOLD_SLACK_MARGIN: 0.2
 GRT_RESIZER_HOLD_SLACK_MARGIN: 0.1
-
-# Floorplanning
-FP_SIZING: absolute
-# 3880umx5070um including 26um
-# for the sealring on all sides
-DIE_AREA: [0, 0, 3932, 5122]
-CORE_AREA: [442, 442, 3490, 4680]
 
 # Increase for more logic
 # on your die
@@ -271,7 +161,7 @@ MACROS:
         - dir::../ip/gf180mcu_ws_ip__logo/lib/gf180mcu_ws_ip__logo.lib
     instances:
       wafer_space_logo:
-        location: [3762.75, 4952.75]
+        location: ["expr::$DIE_AREA[2] + -169.25", "expr::$DIE_AREA[3] + -169.25"]
         orientation: N
 
   gf180mcu_fd_ip_sram__sram512x8m8wm1:
@@ -291,10 +181,10 @@ MACROS:
     instances:
       # Make sure to specify the SRAMs in pdn_cfg.tcl
       i_chip_core.sram_0:
-        location: [500, 500]
+        location: [490, 500]
         orientation: N
       i_chip_core.sram_1:
-        location: [1000, 500]
+        location: [970, 500]
         orientation: E
 
 # This is an alternative method compared to

--- a/librelane/slots/slot_0p5x0p5.yaml
+++ b/librelane/slots/slot_0p5x0p5.yaml
@@ -1,0 +1,94 @@
+# Floorplanning
+FP_SIZING: absolute
+DIE_AREA: [0, 0, 1936, 2531]
+CORE_AREA: [442, 442, 1494, 2089]
+
+VERILOG_DEFINES: ["SLOT_0P5X0P5"]
+
+# Specify the pad instances for the padring
+PAD_SOUTH: [
+    clk_pad,
+    rst_n_pad,
+
+    "dvss_pads\\[0\\].pad",
+    "dvdd_pads\\[0\\].pad",
+
+    "bidir\\[0\\].pad",
+    "bidir\\[1\\].pad",
+    "bidir\\[2\\].pad",
+    "bidir\\[3\\].pad",
+    "bidir\\[4\\].pad",
+    "bidir\\[5\\].pad",
+    "bidir\\[6\\].pad"
+
+]
+
+PAD_EAST: [
+
+    "bidir\\[7\\].pad",
+    "bidir\\[8\\].pad",
+    "bidir\\[9\\].pad",
+    "bidir\\[10\\].pad",
+    "bidir\\[11\\].pad",
+    "bidir\\[12\\].pad",
+    "bidir\\[13\\].pad",
+    "bidir\\[14\\].pad",
+    "bidir\\[15\\].pad",
+    "bidir\\[16\\].pad",
+    "bidir\\[17\\].pad",
+    "bidir\\[18\\].pad",
+    "bidir\\[19\\].pad",
+    "bidir\\[20\\].pad",
+    "bidir\\[21\\].pad",
+            
+            
+    "dvss_pads\\[1\\].pad",
+    "dvdd_pads\\[1\\].pad"
+]
+
+PAD_NORTH: [
+    "analog\\[3\\].pad",
+    "analog\\[2\\].pad",
+
+    "dvss_pads\\[2\\].pad",
+    "dvdd_pads\\[2\\].pad",
+
+    "analog\\[1\\].pad",
+    "analog\\[0\\].pad",
+    
+
+    "bidir\\[26\\].pad",
+    "bidir\\[25\\].pad",
+    "bidir\\[24\\].pad",
+    "bidir\\[23\\].pad",
+    "bidir\\[22\\].pad"
+
+
+]
+
+
+PAD_WEST: [
+
+
+    "bidir\\[37\\].pad",
+    "bidir\\[36\\].pad",
+    "bidir\\[35\\].pad",
+    "bidir\\[34\\].pad",
+    "bidir\\[33\\].pad",
+    "bidir\\[32\\].pad",
+    "bidir\\[31\\].pad",
+    "bidir\\[30\\].pad",
+    "bidir\\[29\\].pad",
+    "bidir\\[28\\].pad",
+    "bidir\\[27\\].pad",
+
+
+    "inputs\\[3\\].pad",
+    "inputs\\[2\\].pad",
+    
+    "dvss_pads\\[3\\].pad",
+    "dvdd_pads\\[3\\].pad",
+    
+    "inputs\\[1\\].pad",
+    "inputs\\[0\\].pad"
+]

--- a/librelane/slots/slot_0p5x1.yaml
+++ b/librelane/slots/slot_0p5x1.yaml
@@ -1,0 +1,109 @@
+# Floorplanning
+FP_SIZING: absolute
+DIE_AREA: [0, 0, 1936, 5122]
+CORE_AREA: [442, 442, 1494, 4680]
+
+VERILOG_DEFINES: ["SLOT_0P5X1"]
+
+# Specify the pad instances for the padring
+PAD_SOUTH: [
+    clk_pad,
+    rst_n_pad,
+    "inputs\\[0\\].pad",
+
+    "dvss_pads\\[0\\].pad",
+    "dvdd_pads\\[0\\].pad",
+    
+    "inputs\\[1\\].pad",
+    "inputs\\[2\\].pad",
+    "inputs\\[3\\].pad"
+]
+
+PAD_EAST: [
+
+    "bidir\\[0\\].pad",
+    "bidir\\[1\\].pad",
+    
+    "dvss_pads\\[1\\].pad",
+    "dvdd_pads\\[1\\].pad",
+    
+    "bidir\\[2\\].pad",
+    "bidir\\[3\\].pad",
+    "bidir\\[4\\].pad",
+    "bidir\\[5\\].pad",
+    "bidir\\[6\\].pad",
+    "bidir\\[7\\].pad",
+    "bidir\\[8\\].pad",
+    "bidir\\[9\\].pad",
+    "bidir\\[10\\].pad",
+    
+    "dvss_pads\\[2\\].pad",
+    "dvdd_pads\\[2\\].pad",
+    
+    "bidir\\[11\\].pad",
+    "bidir\\[12\\].pad",
+    "bidir\\[13\\].pad",
+    "bidir\\[14\\].pad",
+    "bidir\\[15\\].pad",
+    "bidir\\[16\\].pad",
+    "bidir\\[17\\].pad",
+    "bidir\\[18\\].pad",
+    "bidir\\[19\\].pad",
+    
+    "dvss_pads\\[3\\].pad",
+    "dvdd_pads\\[3\\].pad",
+    
+    "bidir\\[20\\].pad",
+    "bidir\\[21\\].pad"
+]
+
+PAD_NORTH: [
+    "analog\\[5\\].pad",
+    "analog\\[4\\].pad",
+    "analog\\[3\\].pad",
+
+    "dvss_pads\\[4\\].pad",
+    "dvdd_pads\\[4\\].pad",
+
+    "analog\\[2\\].pad",
+    "analog\\[1\\].pad",
+    "analog\\[0\\].pad"
+]
+
+
+PAD_WEST: [
+    "bidir\\[43\\].pad",
+    "bidir\\[42\\].pad",
+    "bidir\\[41\\].pad",
+    
+    "dvss_pads\\[7\\].pad",
+    "dvdd_pads\\[7\\].pad",
+    
+    "bidir\\[40\\].pad",
+    "bidir\\[39\\].pad",
+    "bidir\\[38\\].pad",
+    "bidir\\[37\\].pad",
+    "bidir\\[36\\].pad",
+    "bidir\\[35\\].pad",
+    "bidir\\[34\\].pad",
+    "bidir\\[33\\].pad",
+
+    "dvss_pads\\[6\\].pad",
+    "dvdd_pads\\[6\\].pad",
+
+    "bidir\\[32\\].pad",
+    "bidir\\[31\\].pad",
+    "bidir\\[30\\].pad",
+    "bidir\\[29\\].pad",
+    "bidir\\[28\\].pad",
+    "bidir\\[27\\].pad",
+    "bidir\\[26\\].pad",
+    "bidir\\[25\\].pad",
+    "bidir\\[24\\].pad",
+
+    "dvss_pads\\[5\\].pad",
+    "dvdd_pads\\[5\\].pad",
+
+    "bidir\\[23\\].pad",
+    "bidir\\[22\\].pad"
+]

--- a/librelane/slots/slot_1x0p5.yaml
+++ b/librelane/slots/slot_1x0p5.yaml
@@ -1,0 +1,105 @@
+# Floorplanning
+FP_SIZING: absolute
+DIE_AREA: [0, 0, 3932, 2531]
+CORE_AREA: [442, 442, 3490, 2089]
+
+VERILOG_DEFINES: ["SLOT_1X0P5"]
+
+# Specify the pad instances for the padring
+PAD_SOUTH: [
+    clk_pad,
+    rst_n_pad,
+    "bidir\\[0\\].pad",
+    "bidir\\[1\\].pad",
+
+    "dvss_pads\\[0\\].pad",
+    "dvdd_pads\\[0\\].pad",
+
+    "bidir\\[2\\].pad",
+    "bidir\\[3\\].pad",
+    "bidir\\[4\\].pad",
+    "bidir\\[5\\].pad",
+    "bidir\\[6\\].pad",
+    "bidir\\[7\\].pad",
+    "bidir\\[8\\].pad",
+    "bidir\\[9\\].pad",
+    "bidir\\[10\\].pad",
+    "bidir\\[11\\].pad",
+    "bidir\\[12\\].pad",
+    "bidir\\[13\\].pad",
+
+    "dvss_pads\\[1\\].pad",
+    "dvdd_pads\\[1\\].pad",
+    
+    "bidir\\[14\\].pad",
+    "bidir\\[15\\].pad",
+    "bidir\\[16\\].pad",
+    "bidir\\[17\\].pad"
+]
+
+PAD_EAST: [
+    "dvss_pads\\[2\\].pad",
+    "dvdd_pads\\[2\\].pad",
+
+    "bidir\\[18\\].pad",
+    "bidir\\[19\\].pad",
+    "bidir\\[20\\].pad",
+    "bidir\\[21\\].pad",
+    "bidir\\[22\\].pad",
+    "bidir\\[23\\].pad",
+    "bidir\\[24\\].pad",
+    "bidir\\[25\\].pad",
+
+    "dvss_pads\\[3\\].pad",
+    "dvdd_pads\\[3\\].pad"
+]
+
+PAD_NORTH: [
+    "bidir\\[45\\].pad",
+    "bidir\\[44\\].pad",
+    "bidir\\[43\\].pad",
+    "bidir\\[42\\].pad",
+    
+    "dvss_pads\\[5\\].pad",
+    "dvdd_pads\\[5\\].pad",
+
+    "bidir\\[41\\].pad",
+    "bidir\\[40\\].pad",
+    "bidir\\[39\\].pad",
+    "bidir\\[38\\].pad",
+    "bidir\\[37\\].pad",
+    "bidir\\[36\\].pad",
+    "bidir\\[35\\].pad",
+    "bidir\\[34\\].pad",
+    "bidir\\[33\\].pad",
+    "bidir\\[32\\].pad",
+    "bidir\\[31\\].pad",
+    "bidir\\[30\\].pad",
+
+    "dvss_pads\\[4\\].pad",
+    "dvdd_pads\\[4\\].pad",
+    
+    "bidir\\[29\\].pad",
+    "bidir\\[28\\].pad",
+    "bidir\\[27\\].pad",
+    "bidir\\[26\\].pad"
+]
+
+
+PAD_WEST: [
+    "dvss_pads\\[7\\].pad",
+    "dvdd_pads\\[7\\].pad",
+
+    "inputs\\[3\\].pad",
+    "inputs\\[2\\].pad",
+    "inputs\\[1\\].pad",
+    "inputs\\[0\\].pad",
+    
+    "analog\\[3\\].pad",
+    "analog\\[2\\].pad",
+    "analog\\[1\\].pad",
+    "analog\\[0\\].pad",
+    
+    "dvss_pads\\[6\\].pad",
+    "dvdd_pads\\[6\\].pad"
+]

--- a/librelane/slots/slot_1x1.yaml
+++ b/librelane/slots/slot_1x1.yaml
@@ -1,0 +1,111 @@
+# Floorplanning
+FP_SIZING: absolute
+# 3880umx5070um including 26um
+# for the sealring on all sides
+DIE_AREA: [0, 0, 3932, 5122]
+CORE_AREA: [442, 442, 3490, 4680]
+
+VERILOG_DEFINES: ["SLOT_1X1"]
+
+# Specify the pad instances for the padring
+PAD_SOUTH: [
+    clk_pad,
+    rst_n_pad,
+
+    "bidir\\[0\\].pad",
+    "bidir\\[1\\].pad",
+    "bidir\\[2\\].pad",
+    "bidir\\[3\\].pad",
+    "bidir\\[4\\].pad",
+    "bidir\\[5\\].pad",
+
+    "dvss_pads\\[0\\].pad",
+
+    "bidir\\[6\\].pad",
+    "bidir\\[7\\].pad",
+    "bidir\\[8\\].pad",
+    "bidir\\[9\\].pad",
+    "bidir\\[10\\].pad",
+    "bidir\\[11\\].pad",
+    "bidir\\[12\\].pad",
+    "bidir\\[13\\].pad"
+]
+
+PAD_EAST: [
+    "dvdd_pads\\[0\\].pad",
+    "dvss_pads\\[1\\].pad",
+
+    "bidir\\[14\\].pad",
+    "bidir\\[15\\].pad",
+    "bidir\\[16\\].pad",
+    "bidir\\[17\\].pad",
+    "bidir\\[18\\].pad",
+    "bidir\\[19\\].pad",
+    
+    "dvdd_pads\\[1\\].pad",
+    "dvss_pads\\[2\\].pad",
+
+    
+    "bidir\\[20\\].pad",
+    "bidir\\[21\\].pad",
+    "bidir\\[22\\].pad",
+    "bidir\\[23\\].pad",
+    "bidir\\[24\\].pad",
+    "bidir\\[25\\].pad",
+    
+    "dvss_pads\\[3\\].pad",
+    "dvdd_pads\\[2\\].pad",
+    "dvss_pads\\[4\\].pad",
+    "dvdd_pads\\[3\\].pad",
+]
+
+PAD_NORTH: [
+    "analog\\[1\\].pad",
+    "analog\\[0\\].pad",
+    "bidir\\[39\\].pad",
+    "bidir\\[38\\].pad",
+    "bidir\\[37\\].pad",
+    "bidir\\[36\\].pad",
+    "bidir\\[35\\].pad",
+    "bidir\\[34\\].pad",
+
+    "dvss_pads\\[5\\].pad",
+
+    "bidir\\[33\\].pad",
+    "bidir\\[32\\].pad",
+    "bidir\\[31\\].pad",
+    "bidir\\[30\\].pad",
+    "bidir\\[29\\].pad",
+    "bidir\\[28\\].pad",
+    "bidir\\[27\\].pad",
+    "bidir\\[26\\].pad"
+]
+
+
+PAD_WEST: [
+    "dvdd_pads\\[7\\].pad",
+    "dvss_pads\\[9\\].pad",
+    "dvdd_pads\\[6\\].pad",
+    "dvss_pads\\[8\\].pad",
+
+    "inputs\\[11\\].pad",
+    "inputs\\[10\\].pad",
+    "inputs\\[9\\].pad",
+    "inputs\\[8\\].pad",
+    "inputs\\[7\\].pad",
+    "inputs\\[6\\].pad",
+
+    "dvdd_pads\\[5\\].pad",
+    "dvss_pads\\[7\\].pad",
+
+    "inputs\\[5\\].pad",
+    "inputs\\[4\\].pad",
+    "inputs\\[3\\].pad",
+    "inputs\\[2\\].pad",
+
+    "dvdd_pads\\[4\\].pad",
+    "dvss_pads\\[6\\].pad",
+    
+    "inputs\\[1\\].pad",
+    "inputs\\[0\\].pad"
+]

--- a/src/chip_top.sv
+++ b/src/chip_top.sv
@@ -3,15 +3,17 @@
 
 `default_nettype none
 
+`include "slot_defines.svh"
+
 module chip_top #(
     // Power/ground pads for core and I/O
-    parameter NUM_DVDD_PADS = 8,
-    parameter NUM_DVSS_PADS = 10,
+    parameter NUM_DVDD_PADS = `NUM_DVDD_PADS,
+    parameter NUM_DVSS_PADS = `NUM_DVSS_PADS,
 
     // Signal pads
-    parameter NUM_INPUT_PADS = 12,
-    parameter NUM_BIDIR_PADS = 40,
-    parameter NUM_ANALOG_PADS = 2
+    parameter NUM_INPUT_PADS = `NUM_INPUT_PADS,
+    parameter NUM_BIDIR_PADS = `NUM_BIDIR_PADS,
+    parameter NUM_ANALOG_PADS = `NUM_ANALOG_PADS
     )(
     `ifdef USE_POWER_PINS
     inout  wire VDD,

--- a/src/slot_defines.svh
+++ b/src/slot_defines.svh
@@ -1,0 +1,51 @@
+`ifdef SLOT_1X1
+
+// Power/ground pads for core and I/O
+`define NUM_DVDD_PADS 8
+`define NUM_DVSS_PADS 10
+
+// Signal pads
+`define NUM_INPUT_PADS 12
+`define NUM_BIDIR_PADS 40
+`define NUM_ANALOG_PADS 2
+
+`endif
+
+`ifdef SLOT_0P5X1
+
+// Power/ground pads for core and I/O
+`define NUM_DVDD_PADS 8
+`define NUM_DVSS_PADS 8
+
+// Signal pads
+`define NUM_INPUT_PADS 4
+`define NUM_BIDIR_PADS 44
+`define NUM_ANALOG_PADS 6
+
+`endif
+
+`ifdef SLOT_1X0P5
+
+// Power/ground pads for core and I/O
+`define NUM_DVDD_PADS 8
+`define NUM_DVSS_PADS 8
+
+// Signal pads
+`define NUM_INPUT_PADS 4
+`define NUM_BIDIR_PADS 46
+`define NUM_ANALOG_PADS 4
+
+`endif
+
+`ifdef SLOT_0P5X0P5
+
+// Power/ground pads for core and I/O
+`define NUM_DVDD_PADS 4
+`define NUM_DVSS_PADS 4
+
+// Signal pads
+`define NUM_INPUT_PADS 4
+`define NUM_BIDIR_PADS 38
+`define NUM_ANALOG_PADS 4
+
+`endif


### PR DESCRIPTION
This PR adds support for the following slot sizes to the template: `1x1`, `0p5x1`, `1x0p5`, `0p5x0p5`.
Simply set `SLOT` before invoking any of the make commands. For example, to build the design:

```
SLOT=0p5x0p5 make librelane
```

Alternatively, you can export the slot size:

```
export SLOT=0p5x0p5
```

Or, you can change the default in the Makefile.

---

The CI builds the example design for all four slot sizes if in `wafer-space/gf180mcu-project-template`.