### PR TITLE
Fix OCD IOs and update LibreLane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOP = chip_top
 
 PDK_ROOT ?= $(MAKEFILE_DIR)/gf180mcu
 PDK ?= gf180mcuD
-PDK_COMMIT ?= 9233c19260cd813c3fa67dd4594fe4cc67016832
+PDK_COMMIT ?= f6bfbd4d3d23c4236ff1f36126489ee59aa35cbd
 
 # Available SCL libraries:
 # gf180mcu_as_sc_mcu7t3v3

--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         "nix-eda": "nix-eda"
       },
       "locked": {
-        "lastModified": 1780404504,
-        "narHash": "sha256-6vG/vmpV4YA74t6XPlX0HoCCaILaFDarYgHePGSkXuY=",
+        "lastModified": 1780916960,
+        "narHash": "sha256-UJm6kmpI0BbKf7OPwysAtRCTYHCjBBHI7x+ppH0hIeA=",
         "owner": "librelane",
         "repo": "librelane",
-        "rev": "cdc8091a732d9a9004925fd0584cc6acf03c9838",
+        "rev": "531569a251c493a91905b4596e494c29da99dd0b",
         "type": "github"
       },
       "original": {
@@ -84,16 +84,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780046302,
-        "narHash": "sha256-OpggEUoz/n8b+mBFhNpQ3PonbEiHaN2oh4j8oyqT77E=",
+        "lastModified": 1780909493,
+        "narHash": "sha256-DI5j5e387Otx7KQFjaGR4iXOl4+h0s5aR/HXo28cbhU=",
         "owner": "fossi-foundation",
         "repo": "nix-eda",
-        "rev": "f98b2f0e977357adf1897fd3da0a554c8276b9c8",
+        "rev": "ebee72ea782641c04291dfa4cdcb560d22047bab",
         "type": "github"
       },
       "original": {
         "owner": "fossi-foundation",
-        "ref": "6.21.0",
+        "ref": "6.24.0",
         "repo": "nix-eda",
         "type": "github"
       }


### PR DESCRIPTION
- Update PDK to `f6bfbd4d`
  - Fixes `Y` direction of `*_in_s` pad cell
- Update LibreLane dev
  - Solves the issue with magic max open file descriptor limit