### PR TITLE
chore: update PDK hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOP = chip_top
 
 PDK_ROOT ?= $(MAKEFILE_DIR)/gf180mcu
 PDK ?= gf180mcuD
-PDK_COMMIT ?= 140b0494c6665b10ce9353cb1c2ef5bcc18e7d66
+PDK_COMMIT ?= d658698bd8bcf4e05fc7b5991a701247ba0d744c
 
 # Available SCL libraries:
 # gf180mcu_as_sc_mcu7t3v3


### PR DESCRIPTION
Fixes the poly2 density check and adds the comp density checks.
I previously forgot to upstream these changes from the PDK fork.