### PR TITLE
[CI] Pull git submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           nix_cache_domain: ${{ vars.NIX_CACHE }}
           nix_public_key: ${{ vars.NIX_PUBLIC_KEY }}
+          submodules: 'true'
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
@@ -79,12 +80,6 @@ jobs:
         run: |
           sudo du -hs /nix/store/* | sort -h | tail -n 10
           sudo tree /nix/store/*-librelane || true
-      - name: Configure submodules to use HTTPS based addresses
-        run: |
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-      - name: Pull Submodules
-        run: |
-          git submodule update --init --recursive
       - name: Clone the PDK
         run: |
           nix develop --command make clone-pdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,14 @@ jobs:
           remove-codeql: "true"
           remove-docker-images: "true"
       - uses: actions/checkout@v6
+        with:
+           submodules: recursive
       - name: Setup Nix
         uses: ./.github/actions/setup_nix
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           nix_cache_domain: ${{ vars.NIX_CACHE }}
           nix_public_key: ${{ vars.NIX_PUBLIC_KEY }}
-          submodules: true
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           nix_cache_domain: ${{ vars.NIX_CACHE }}
           nix_public_key: ${{ vars.NIX_PUBLIC_KEY }}
-          submodules: 'true'
+          submodules: true
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
         run: |
           sudo du -hs /nix/store/* | sort -h | tail -n 10
           sudo tree /nix/store/*-librelane || true
+      - name: Configure submodules to use HTTPS based addresses
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - name: Pull Submodules
+        run: |
+          git submodule update --init --recursive
       - name: Clone the PDK
         run: |
           nix develop --command make clone-pdk


### PR DESCRIPTION
**Problem:** 
Current workflow will fail if there are dependencies on sub modules given they are currently not pulled when the git is initialized. 

**Changes:**
Adding steps to pull in git sub modules to the workflow. 
This flow overwrites the base sub module address to use `https` in order to not need a properly configured github access token for pulling in the sub modules. As such no additional configuration is needed for this to just work. 

**Limitations:**
As stated above, since the submodule pull doesn't use a github access token this only works out of the box on publicly accessible endpoints, aka: public repo's. 
This current submodule pull will fail if the submodules are private repo's. 